### PR TITLE
Change extract_jpg to search, extract, and save all jpgs in PDZ

### DIFF
--- a/notebooks/20_extracting-image-data.ipynb
+++ b/notebooks/20_extracting-image-data.ipynb
@@ -24,7 +24,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "abffc94b-c99c-40da-9b86-c475aa7d3f8d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "#|default_exp jpg_extractor "
@@ -34,7 +38,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7ba50662-e047-4b42-aacc-9e8ab1135ff2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "#|hide \n",
@@ -46,7 +54,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "58d72cb0-9c4c-4c9e-a381-b2bd69effe16",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -87,14 +99,18 @@
    "id": "75b5a004-3577-40da-a32e-883b5299fc88",
    "metadata": {},
    "source": [
-    "The newest Bruker Tracer XRF spectrometers are equipped with a simple RGB camera that can record the location of the spectral measurement. This RGB image is then encoded as jpg binary data that is stored within a specific block (type 137) in the pdz file. If a pdz file actually contains image data you can use the `extract_jpg()` function to get it out.    "
+    "The newest Bruker Tracer XRF spectrometers are equipped with a simple RGB camera that can record the location of the spectral measurement. This RGB image is then encoded as jpg binary data that is stored within a specific block (type 137) in the pdz file. Some pdz files contain multiple jpg images. If a pdz file actually contains image data you can use the `extract_jpg()` function to get them out.    "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "37538149-5742-4e10-851f-b435b2466f79",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from read_pdz import extract_jpg "
@@ -104,7 +120,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e5867d3a-c1c6-441d-8b07-78083557d617",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -116,7 +136,7 @@
    ],
    "source": [
     "pdz_file = '/home/frank/Work/DATA/read-pdz-demodata/00081-Precious Metals 2.pdz' # contains jpg image \n",
-    "im = extract_jpg(pdz_file, save_file=True)"
+    "ims = extract_jpg(pdz_file, save_file=True)"
    ]
   },
   {
@@ -131,7 +151,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "955a7970-9f20-468b-872f-eb58ad29995f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "#|code-fold: true \n",
@@ -142,7 +166,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4a4f58e3-46d5-4726-9f5e-cdfb85195770",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -158,7 +186,7 @@
    "source": [
     "#|code-fold: true\n",
     "fig, ax = plt.subplots()\n",
-    "ax.imshow(im);"
+    "ax.imshow(ims[0]);"
    ]
   },
   {
@@ -173,7 +201,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9f03fa86-83a8-4e20-84d8-0632e63397f2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "#|export \n",
@@ -190,13 +222,20 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b7af3ca3-fc08-4a1f-bf30-537e104dbd56",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "#|export \n",
     "\n",
     "def extract_jpg(pdz_file, BLOCKTYPE=137, save_file=False): \n",
-    "    '''Extract jpg image from `pdz_file`.'''\n",
+    "    '''Extract and save jpg images from `pdz_file`.\n",
+    "    \n",
+    "    Returns a list of jpg images where ims = [ im0, im1, ... ].\n",
+    "    '''\n",
     "    \n",
     "    # parse into blocks \n",
     "    pdz_bytes = file_to_bytes(pdz_file)\n",
@@ -209,22 +248,34 @@
     "        print(f'Could not find jpg image data in: {pdz_file}')\n",
     "\n",
     "    else: \n",
-    "        jpg_i = blocktypes_list.index(137)\n",
+    "        jpg_i = blocktypes_list.index(BLOCKTYPE)\n",
     "        jpg_dict = block_list[jpg_i]\n",
     "        jpg_sandwich = jpg_dict['bytes'].tobytes()\n",
-    "    \n",
-    "        jpg_start = re.search(b'\\xff\\xd8', jpg_sandwich).span()[0]\n",
-    "        jpg_end = re.search(b'\\xff\\xd9', jpg_sandwich).span()[1]\n",
-    "        jpg = jpg_sandwich[jpg_start:jpg_end]\n",
-    "    \n",
-    "        im = np.array(Image.open(io.BytesIO(jpg))) \n",
     "\n",
-    "        if save_file is True: \n",
-    "            jpg_file = re.sub('\\.pdz$', '.jpg', pdz_file) \n",
-    "            print(f\"Saving image file: '{jpg_file}'\")\n",
-    "            plt.imsave(jpg_file, im) \n",
+    "        # Repeatedly search for jpgs by consuming jpg_sandwich\n",
+    "        ims = []\n",
+    "        while True:\n",
+    "            match_jpg_start = re.search(b'\\xff\\xd8', jpg_sandwich)\n",
+    "            match_jpg_end = re.search(b'\\xff\\xd9', jpg_sandwich)\n",
+    "    \n",
+    "            if not match_jpg_start or not match_jpg_end:\n",
+    "                break\n",
     "\n",
-    "        return im \n",
+    "            jpg_start = match_jpg_start.span()[0]\n",
+    "            jpg_end = match_jpg_end.span()[1]\n",
+    "            jpg = jpg_sandwich[jpg_start:jpg_end]\n",
+    "            \n",
+    "            ims.append(np.array(Image.open(io.BytesIO(jpg))))\n",
+    "\n",
+    "            jpg_sandwich = jpg_sandwich[jpg_end:]\n",
+    "\n",
+    "        if save_file is True:\n",
+    "            for i, im in enumerate(ims):\n",
+    "                jpg_file = re.sub('\\.pdz$', f'-{i}.jpg', pdz_file)\n",
+    "                print(f\"Saving image file: '{jpg_file}'\")\n",
+    "                plt.imsave(jpg_file, im) \n",
+    "\n",
+    "        return ims\n",
     "\n",
     "    return None "
    ]

--- a/read_pdz/jpg_extractor.py
+++ b/read_pdz/jpg_extractor.py
@@ -37,7 +37,7 @@ def extract_jpg(pdz_file, BLOCKTYPE=137, save_file=False):
         im = np.array(Image.open(io.BytesIO(jpg))) 
 
         if save_file is True: 
-            jpg_file = re.sub('\.pdz$', '.jpg', pdz_file) 
+            jpg_file = re.sub('\\.pdz$', '.jpg', pdz_file) 
             print(f"Saving image file: '{jpg_file}'")
             plt.imsave(jpg_file, im) 
 


### PR DESCRIPTION
Here is my proposal for #1 to search, extract, and save all jpgs in a PDZ using `extract_jpg`.

**Note: I have _not_ rerun the notebooks nor regenerated the package as I do not currently have `nbdev` on my machine.**

## Changes

### Function `extract_jpg`:

Returns a Python list `ims` containing all found jpgs where `ims = [ im0, im1, ... ]`. 
This is different than directly returning the first image `im`.

Saves images with a number appended to the filename:

- `ims[0] -> 00000-original pdz filename-0.jpg`
- `ims[1] -> 00000-original pdz filename-1.jpg`
- `ims[n] -> 00000-original pdz filename-n.jpg`

This is different than saving the first image with the original filename with no appended text.